### PR TITLE
build(deps): Use dynamic patch versions for Gradle dependencies and plugins

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -6,7 +6,7 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.springframework.boot)
-    id("org.openapi.generator") version "7.14.0"
+    id("org.openapi.generator") version "7.14.+"
     id("io.spring.dependency-management")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,10 +4,10 @@ plugins {
     alias(libs.plugins.kotlin.jpa)
     alias(libs.plugins.springframework.boot)
     id("io.spring.dependency-management")
-    id("com.diffplug.spotless") version "7.0.4"
+    id("com.diffplug.spotless") version "7.1.+"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
-    id("com.google.cloud.tools.jib") version "3.4.5"
-    id("com.gorylenko.gradle-git-properties") version "2.5.0"
+    id("com.google.cloud.tools.jib") version "3.4.+"
+    id("com.gorylenko.gradle-git-properties") version "2.5.+"
 }
 
 
@@ -35,8 +35,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.apache.commons:commons-lang3:3.17.0")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
+    implementation("org.apache.commons:commons-lang3:3.17.+")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.+")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
@@ -45,10 +45,10 @@ dependencies {
     testRuntimeOnly("com.h2database:h2")
     detektPlugins("com.github.ablil:detekt-extension:v0.1.0")
     // https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
-    implementation("ch.qos.logback:logback-classic:1.5.18")
+    implementation("ch.qos.logback:logback-classic:1.5.+")
     // https://mvnrepository.com/artifact/net.logstash.logback/logstash-logback-encoder
     implementation("net.logstash.logback:logstash-logback-encoder:8.1")
-    runtimeOnly("com.github.ben-manes.caffeine:caffeine:3.2.1")
+    runtimeOnly("com.github.ben-manes.caffeine:caffeine:3.2.+")
     runtimeOnly("org.hibernate.orm:hibernate-micrometer")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,5 +5,5 @@ kotlinVersion = "2.0.21"
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinVersion" }
 kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlinVersion" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlinVersion" }
-springframework-boot = { id = "org.springframework.boot", version = "3.5.3" }
-springframework-dependencymanagement = {id = "io.spring.dependency-management", version = "1.1.7"}
+springframework-boot = { id = "org.springframework.boot", version = "3.5.+" }
+springframework-dependencymanagement = {id = "io.spring.dependency-management", version = "1.1.+"}


### PR DESCRIPTION
This change updates various plugin and library versions across the build configuration files (`build.gradle.kts` and `libs.versions.toml`) from fixed patch versions (e.g., `X.Y.Z`) to dynamic 'latest patch' versions (e.g., `X.Y.+`).

This approach allows Gradle to automatically pick up the latest bug fixes and minor improvements within the specified major.minor version range, reducing the need for manual version bumps for patch releases and improving overall project maintainability.
