### PR TITLE
feat(mail): Introduce local SMTP with MailHog and refine user email details

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ set through `example.technical-user.username` and `example.technical-user.passwo
 
 When enabled, spring security will expose actuator endpoints through basic auth with the specified credentials (above)
 
+## Mail
+
+if `mail.host` is provided, mail will be configured, otherwise it will be ignored and all email will be logged (warning level).
+
+By default, a fake docker image is set on `compose.yaml` file with a web interface.
+
+smtp server: http://localhost:1025
+
+web ui: http://localhost:8025
+
 # Tips
 
 Extract all environment variable defined in `application.yaml`

--- a/app/src/main/kotlin/com/example/common/events/EmailEventsListeners.kt
+++ b/app/src/main/kotlin/com/example/common/events/EmailEventsListeners.kt
@@ -47,7 +47,7 @@ class EmailEventsListeners(
                     setVariables(
                         mapOf(
                             "applicationName" to applicationName,
-                            "fullName" to event.user.fullName,
+                            "fullName" to (event.user.fullName ?: event.user.email),
                             "activationLink" to
                                 "%s?key=%s"
                                     .format(
@@ -66,7 +66,8 @@ class EmailEventsListeners(
             to = event.user.email,
             title = "Account activation",
             template = "accountActivated",
-            context = Context().apply { setVariable("fullName", event.user.fullName) },
+            context =
+                Context().apply { setVariable("fullName", event.user.fullName ?: event.user.email) },
         )
     }
 

--- a/app/src/main/kotlin/com/example/users/DomainUser.kt
+++ b/app/src/main/kotlin/com/example/users/DomainUser.kt
@@ -29,7 +29,7 @@ class DomainUser(
     @Column(unique = true) var username: String,
     @Column(unique = true) var email: String,
     @JsonIgnore var password: String,
-    var status: UserStatus = UserStatus.INACTIVE,
+    @Enumerated(EnumType.STRING) var status: UserStatus = UserStatus.INACTIVE,
     @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = FetchType.EAGER, targetClass = AuthorityConstants::class)
     @CollectionTable(name = "authorities")
@@ -80,7 +80,7 @@ class DomainUser(
     }
 
     val fullName: String?
-        get() = "%s %s".format(firstName, lastName)
+        get() = listOfNotNull(lastName, firstName).takeUnless { it.isEmpty() }?.joinToString(" ")
 
     fun isActive(): Boolean = UserStatus.ACTIVE == this.status
 

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -21,11 +21,11 @@ spring:
     properties:
       hibernate:
         generate_statistics: false
-#  mail:
-#    host: ${MAIL_HOST}
-#    port: 25
-#    username: ${MAIL_USERNAME}
-#    password: ${MAIL_PASSWORD}
+  mail:
+    host: ${SMTP_SERVER:0.0.0.0}
+    port: ${SMTP_PORT:1025}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
 
 management:
   simple:
@@ -48,7 +48,7 @@ management:
 # custom application properties
 example:
   application:
-    base-url: https://example.com
+    base-url: http://0.0.0.0:8080
     urls:
       activation-link: ${example.application.base-url}/api/v1/accounts/activate
       reset-password-link: ${example.application.base-url}/reset

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,13 @@ services:
     ports:
       - 5432:5432
 
+  smtp:
+    image: mailhog/mailhog:v1.0.1
+    container_name: smtp
+    ports:
+      - 1025:1025
+      - 8025:8025 # web interface
+
   app:
     image: spring-starter-template:latest
     ports:


### PR DESCRIPTION
Added MailHog service to compose.yaml for local email testing and development.Configured Spring Mail properties in application.yaml to utilize the new SMTP setup.Updated README.md with documentation for mail configuration and MailHog access.Improved DomainUser.fullName getter to handle cases where first or last names are null, ensuring a more robust full name generation.Modified email event listeners to fallback to the user's email address if fullName is not available for email templating.Ensured DomainUser.status enum is persisted as a string in the database using @Enumerated(EnumType.STRING).Adjusted the default example.application.base-url in application.yaml.
